### PR TITLE
Adding more build expressions for MigrationBuilder

### DIFF
--- a/Sources/Monarch/MigrationBuilder.swift
+++ b/Sources/Monarch/MigrationBuilder.swift
@@ -3,4 +3,37 @@ public struct MigrationBuilder {
     public static func buildBlock(_ migrations: Migration...) -> [Migration] {
         return migrations
     }
+
+	public static func buildBlock(_ migrations: [Migration]...) -> [Migration] {
+		migrations.flatMap { $0 }
+	}
+
+	public static func buildExpression(_ expression: Migration) -> [Migration] {
+		[expression]
+	}
+
+	public static func buildExpression(_ expression: [Migration]) -> [Migration] {
+		expression
+	}
+
+	public static func buildOptional(_ migration: [Migration]?) -> [Migration] {
+		migration ?? []
+	}
+
+	public static func buildEither(first migration: [Migration]) -> [Migration] {
+		migration
+	}
+
+	public static func buildEither(second migration: [Migration]) -> [Migration] {
+		migration
+	}
+
+	public static func buildArray(_ migrations: [[Migration]]) -> [Migration] {
+		migrations.flatMap { $0 }
+	}
+
+	public static func buildLimitedAvailability(_ migration: [Migration]) -> [Migration] {
+		migration
+	}
+
 }


### PR DESCRIPTION
I'd previously added `func buildBlock(_ migrations: Migration...) -> [Migration]` as the sole build function in `@MigrationBuilder`, but these additional functions allow us to use conditionals and expressions inside of our `MigrationGroup`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands `MigrationBuilder` with result builder overloads to support conditionals, optionals, arrays, and limited availability.
> 
> - **Result Builder Enhancements** (`Sources/Monarch/MigrationBuilder.swift`):
>   - Add overloads: `buildBlock(_ migrations: [Migration]...)`, `buildExpression(_ expression: Migration|[Migration])`, `buildOptional(_ migration: [Migration]?)`, `buildEither(first|second:)`, `buildArray(_ migrations: [[Migration]])`, `buildLimitedAvailability(_ migration: [Migration])`.
>   - Enables conditionals, optionals, arrays, and limited availability handling within `MigrationBuilder`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 980d45a524d6a06c8a67c021e28d65d31e4bc4b7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->